### PR TITLE
Update package.xml

### DIFF
--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -21,5 +21,5 @@
 		<members>Lightning_Page_Performance_EPT_SITE_TEMPLATES</members>
         <name>WaveXmd</name>
     </types>
-    <version>52.0</version>
+    <version>56.0</version>
 </Package>


### PR DESCRIPTION
bumped api version to 56

Solves "Error Report_Adoption Unrecognized field "textWrap"" when using:
sfdx force:source:deploy -x .\manifest\package.xml