### PR TITLE
removed app template reference

### DIFF
--- a/force-app/main/default/wave/Event_Monitoring_Plus.wapp-meta.xml
+++ b/force-app/main/default/wave/Event_Monitoring_Plus.wapp-meta.xml
@@ -9,6 +9,4 @@
         <sharedTo>AllInternalUsers</sharedTo>
         <sharedToType>Organization</sharedToType>
     </shares>
-    <templateOrigin>sfdc_internal__AdminAnalytics</templateOrigin>
-    <templateVersion>56.0</templateVersion>
 </WaveApplication>

--- a/misc/mdapi/wave/Event_Monitoring_Plus.wapp
+++ b/misc/mdapi/wave/Event_Monitoring_Plus.wapp
@@ -9,6 +9,4 @@
         <sharedTo>AllInternalUsers</sharedTo>
         <sharedToType>Organization</sharedToType>
     </shares>
-    <templateOrigin>sfdc_internal__AdminAnalytics</templateOrigin>
-    <templateVersion>56.0</templateVersion>
 </WaveApplication>


### PR DESCRIPTION
This app reference the Event Monitoring template, v56.0.  As a result, in the UI, a message is displayed indicating that an update is available:

![image](https://github.com/seamusocionnaigh/eventmonitoringplus/assets/69258451/8067e7f7-be39-417e-a1d4-ae8a1ab2d00b)

Clicking "Updating Available" walks the user through a reconfiguration of the Event Monitoring app, which is completely separate from the Event Monitoring Plus app.  This is confusing and misleading.  Although this EMP app certainly depends on some of the datasets created by the core EM app, referencing the EM template is maybe not the best way to convey this dependency.

This PR removes the reference to the EM template.  